### PR TITLE
Use a more efficent way of getting the test task for a variant

### DIFF
--- a/src/main/groovy/com/dicedmelon/gradle/jacoco/android/JacocoAndroidPlugin.groovy
+++ b/src/main/groovy/com/dicedmelon/gradle/jacoco/android/JacocoAndroidPlugin.groovy
@@ -90,7 +90,7 @@ class JacocoAndroidPlugin implements Plugin<ProjectInternal> {
   }
 
   static def testTask(TaskCollection<Task> tasks, variant) {
-    tasks.withType(Test).find { task -> task.name =~ /test${variant.name.capitalize()}UnitTest/ }
+    tasks.getByName("test${variant.name.capitalize()}UnitTest")
   }
 
   static def executionDataFile(Task testTask) {


### PR DESCRIPTION
Per #45: Use `getByName` to search for the name.  Because the name is already known, we don't need to iterate so much.