### PR TITLE
Configure report output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ buildscript {
   }
   dependencies {
     ...
-    classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+    classpath 'com.dicedmelon.gradle:jacoco-android:0.1.5'
   }
 }
 
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'jacoco-android'
 
 jacoco {
-  toolVersion = "0.8.3"
+  toolVersion = "0.8.4"
 }
 
 tasks.withType(Test) {
@@ -64,6 +64,14 @@ jacocoAndroidUnitTestReport {
   csv.enabled false
   html.enabled true
   xml.enabled true
+}
+```
+
+By default your report will be in `[root_project]/[project_name]/build/jacoco/`
+But you can change the local reporting directory :
+```groovy
+jacocoAndroidUnitTestReport {
+  destination "/path/to/the/new/local/directory/"
 }
 ```
 

--- a/src/main/groovy/com/dicedmelon/gradle/jacoco/android/JacocoAndroidPlugin.groovy
+++ b/src/main/groovy/com/dicedmelon/gradle/jacoco/android/JacocoAndroidPlugin.groovy
@@ -83,9 +83,23 @@ class JacocoAndroidPlugin implements Plugin<ProjectInternal> {
       reportTask.classDirectories = javaTree
     }
     reportTask.reports {
+      def destination = project.jacocoAndroidUnitTestReport.destination
+      
       csv.enabled project.jacocoAndroidUnitTestReport.csv.enabled
       html.enabled project.jacocoAndroidUnitTestReport.html.enabled
       xml.enabled project.jacocoAndroidUnitTestReport.xml.enabled
+
+      if (csv.enabled) {
+        csv.destination new File((destination == null) ? "${project.buildDir}/jacoco/jacoco.csv" : "${destination.trim()}/jacoco.csv")
+      }
+      
+      if (html.enabled) {
+        html.destination new File((destination == null) ? "${project.buildDir}/jacoco/jacocoHtml" : "${destination.trim()}/jacocoHtml")
+      }
+
+      if (xml.enabled) {
+        xml.destination new File((destination == null) ? "${project.buildDir}/jacoco/jacoco.xml" : "${destination.trim()}/jacoco.xml")
+      }
     }
     reportTask
   }
@@ -118,5 +132,9 @@ class JacocoAndroidPlugin implements Plugin<ProjectInternal> {
     logger.info("Added $reportTask")
     logger.info("  executionData: $reportTask.executionData.asPath")
     logger.info("  sourceDirectories: $reportTask.sourceDirectories.asPath")
+    logger.info("  csv.destination: $reportTask.reports.csv.destination")
+    logger.info("  xml.destination: $reportTask.reports.xml.destination")
+    logger.info("  html.destination: $reportTask.reports.html.destination")
+
   }
 }

--- a/src/main/groovy/com/dicedmelon/gradle/jacoco/android/JacocoAndroidUnitTestReportExtension.groovy
+++ b/src/main/groovy/com/dicedmelon/gradle/jacoco/android/JacocoAndroidUnitTestReportExtension.groovy
@@ -33,11 +33,13 @@ class JacocoAndroidUnitTestReportExtension {
   ReportConfiguration csv
   ReportConfiguration html
   ReportConfiguration xml
+  String destination
 
   JacocoAndroidUnitTestReportExtension(Collection<String> excludes) {
     this.excludes = excludes
     this.csv = new ReportConfiguration(false)
     this.html = new ReportConfiguration(true)
     this.xml = new ReportConfiguration(true)
+    this.destination = null
   }
 }


### PR DESCRIPTION
To use the jacoco-android plugin in our CI, we need to change the directory path of the generated reports.

I saw an open [issue](https://github.com/arturdm/jacoco-android-gradle-plugin/issues/34) about it.

Thank you and have a good day. 